### PR TITLE
Feat/#7 Home에 포켓몬 데이터를 담은 Card 컴포넌트 렌더링

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,19 +4,8 @@ import Home from "./pages/Home";
 import Detail from "./pages/Detail";
 import Search from "./pages/Search";
 import Favorites from "./pages/Favorites";
-import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { fetchMultiplePokemonById } from "./RTK/thunk";
 
 function App() {
-  const dispatch = useDispatch();
-  const pokemonData = useSelector((state) => state.pokemon);
-  console.log(pokemonData);
-
-  useEffect(() => {
-    dispatch(fetchMultiplePokemonById(151));
-  }, []);
-
   return (
     <BrowserRouter>
       <Routes>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,16 +1,14 @@
-const Card = () => {
+const Card = ({ id, color, name, sprite }) => {
   return (
     <div className="w-50 ml-30 py-4 flex flex-col items-center rounded-xl shadow-[2px_2px_0_2px_#000000]">
-      <img
-        src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png"
-        alt="image"
-        width="150"
-      />
+      <img src={sprite} width="150" />
       <div className="w-fit h-fit border border-solid border-gray-300 flex justify-center items-center rounded-xl">
-        <span className="px-3 py-0.5 bg-green-500 font-semibold rounded-xl">
-          001
+        <span
+          className="px-3 py-0.5 font-semibold rounded-xl"
+          style={{ backgroundColor: `${color}` }}>
+          {id}
         </span>
-        <span className="px-3">이상해씨</span>
+        <span className="px-3">{name}</span>
       </div>
     </div>
   );

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,6 @@
 const Card = ({ id, color, name, sprite }) => {
   return (
-    <div className="w-50 ml-30 py-4 flex flex-col items-center rounded-xl shadow-[2px_2px_0_2px_#000000]">
+    <div className="w-50 py-4 bg-white flex flex-col items-center shrink-0 rounded-xl shadow-[2px_2px_0_2px_#000000] cursor-pointer duration-300 ease-out hover:scale-110">
       <img src={sprite} width="150" />
       <div className="w-fit h-fit border border-solid border-gray-300 flex justify-center items-center rounded-xl">
         <span

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,5 +1,19 @@
 const Card = () => {
-  return <div>Card</div>;
+  return (
+    <div className="w-50 ml-30 py-4 flex flex-col items-center rounded-xl shadow-[2px_2px_0_2px_#000000]">
+      <img
+        src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png"
+        alt="image"
+        width="150"
+      />
+      <div className="w-fit h-fit border border-solid border-gray-300 flex justify-center items-center rounded-xl">
+        <span className="px-3 py-0.5 bg-green-500 font-semibold rounded-xl">
+          001
+        </span>
+        <span className="px-3">이상해씨</span>
+      </div>
+    </div>
+  );
 };
 
 export default Card;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -13,7 +13,7 @@ const Home = () => {
   }, [dispatch]);
 
   return (
-    <div>
+    <div className="px-16 py-8 flex flex-wrap justify-center gap-12 bg-[#747474]">
       {pokemonData.length > 0 &&
         pokemonData.map((el) => (
           <Card

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,10 +1,29 @@
 import Card from "../components/Card";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchMultiplePokemonById } from "../RTK/thunk";
 
 const Home = () => {
+  const dispatch = useDispatch();
+  const pokemonData = useSelector((state) => state.pokemon.data);
+  console.log(pokemonData);
+
+  useEffect(() => {
+    dispatch(fetchMultiplePokemonById(151));
+  }, [dispatch]);
+
   return (
     <div>
-      Home Page
-      <Card />
+      {pokemonData.length > 0 &&
+        pokemonData.map((el) => (
+          <Card
+            key={el.id}
+            id={`${el.id}`.padStart(3, "0")}
+            color={el.color}
+            name={el.name}
+            sprite={el.sprites.front_default}
+          />
+        ))}
     </div>
   );
 };


### PR DESCRIPTION
## 🌱 연관된 이슈

> #7

## 📝 작업 내용

> Home(메인 페이지)에 1세대 포켓몬의 정보를 각각 Card에 담아 map으로 렌더링