### PR TITLE
Refactor/#21 pokeApi 경로 수정

### DIFF
--- a/src/RTK/slice.js
+++ b/src/RTK/slice.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { fetchMultiplePokemonById } from "./thunk";
+import { fetchMultiplePokemonById, fetchPokemonId } from "./thunk";
 
 export const pokemonSlice = createSlice({
   name: "pokemon",
@@ -17,6 +17,28 @@ export const pokemonSlice = createSlice({
         state.loading = false;
       })
       .addCase(fetchMultiplePokemonById.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      });
+  },
+});
+
+export const pokemonIdSlice = createSlice({
+  name: "pokemonId",
+  initialState: {
+    data: [],
+    loading: true,
+  },
+  reducers: {}, // 동기적 상태 변경
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchPokemonId.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchPokemonId.rejected, (state) => {
+        state.loading = false;
+      })
+      .addCase(fetchPokemonId.fulfilled, (state, action) => {
         state.loading = false;
         state.data = action.payload;
       });

--- a/src/RTK/store.js
+++ b/src/RTK/store.js
@@ -1,9 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { favoritesSlice, pokemonSlice } from "./slice";
+import { favoritesSlice, pokemonIdSlice, pokemonSlice } from "./slice";
 
 export const store = configureStore({
   reducer: {
     pokemon: pokemonSlice.reducer,
+    pokemonId: pokemonIdSlice.reducer,
     favorites: favoritesSlice.reducer,
   },
 });

--- a/src/RTK/thunk.js
+++ b/src/RTK/thunk.js
@@ -20,7 +20,7 @@ export const fetchPokemonId = createAsyncThunk(
 export const fetchMultiplePokemonById = createAsyncThunk(
   "pokemon/fetchMultiplePokemonById",
   async (pokemonIdList) => {
-    const getPokemonData = async (pokemonId) => {
+    const getPokemonData = async (pokemonId, count) => {
       const [responseP, responsePS] = await Promise.all([
         fetch(`https://pokeapi.co/api/v2/pokemon/${pokemonId}/`),
         fetch(`https://pokeapi.co/api/v2/pokemon-species/${pokemonId}/`),
@@ -32,7 +32,7 @@ export const fetchMultiplePokemonById = createAsyncThunk(
       ]);
 
       const pokemonData = {
-        id: pokemonId,
+        id: count,
         color: dataPS.color.name,
         desc: dataPS.flavor_text_entries.find((el) => el.language.name === "ko")
           .flavor_text,
@@ -52,6 +52,8 @@ export const fetchMultiplePokemonById = createAsyncThunk(
       return pokemonData;
     };
 
-    return await Promise.all(pokemonIdList.map((el) => getPokemonData(el)));
+    return await Promise.all(
+      pokemonIdList.map((el, idx) => getPokemonData(el, idx + 1))
+    );
   }
 );

--- a/src/RTK/thunk.js
+++ b/src/RTK/thunk.js
@@ -19,37 +19,39 @@ export const fetchPokemonId = createAsyncThunk(
 
 export const fetchMultiplePokemonById = createAsyncThunk(
   "pokemon/fetchMultiplePokemonById",
-  async (maxPokemonId) => {
-    const numberArray = Array.from(
-      { length: maxPokemonId },
-      (_, idx) => idx + 1
-    );
-
+  async (pokemonIdList) => {
     const getPokemonData = async (pokemonId) => {
-      // const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${pokemonId}/`);
-      const response = await fetch(
-        `https://pokeapi.co/api/v2/pokemon-species/${pokemonId}/`
-      );
-      const data = await response.json();
+      const [responseP, responsePS] = await Promise.all([
+        fetch(`https://pokeapi.co/api/v2/pokemon/${pokemonId}/`),
+        fetch(`https://pokeapi.co/api/v2/pokemon-species/${pokemonId}/`),
+      ]);
+
+      const [dataP, dataPS] = await Promise.all([
+        responseP.json(),
+        responsePS.json(),
+      ]);
 
       const pokemonData = {
         id: pokemonId,
-        // types: data.types.map((el) => el.type.name),
-        color: data.color.name,
-        name: data.names.find((el) => el.language.name === "ko").name,
-        desc: data.flavor_text_entries.find((el) => el.language.name === "ko")
+        color: dataPS.color.name,
+        desc: dataPS.flavor_text_entries.find((el) => el.language.name === "ko")
           .flavor_text,
+        genus: dataPS.genera.find((el) => el.language.name === "ko").genus,
+        height: dataP.height,
+        name: dataPS.names.find((el) => el.language.name === "ko").name,
         sprites: {
           front_default: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemonId}.png`,
           back_default: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/${pokemonId}.png`,
           front_shiny: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/shiny/${pokemonId}.png`,
           back_shiny: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/back/shiny/${pokemonId}.png`,
         },
+        types: dataP.types.map((el) => el.type.name),
+        weight: dataP.weight,
       };
 
       return pokemonData;
     };
 
-    return await Promise.all(numberArray.map((el) => getPokemonData(el)));
+    return await Promise.all(pokemonIdList.map((el) => getPokemonData(el)));
   }
 );

--- a/src/RTK/thunk.js
+++ b/src/RTK/thunk.js
@@ -1,5 +1,22 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 
+export const fetchPokemonId = createAsyncThunk(
+  "pokemonId/fetchPokemonId",
+  async () => {
+    const response = await fetch(
+      "https://pokeapi.co/api/v2/pokedex/updated-johto/"
+    );
+    const { pokemon_entries } = await response.json();
+
+    const pokemonId = pokemon_entries.map((el) => {
+      const splits = el.pokemon_species.url.split("/").filter(Boolean);
+      return splits.pop(); // 마지막 요소 반환을 위해 pop 사용
+    });
+
+    return pokemonId;
+  }
+);
+
 export const fetchMultiplePokemonById = createAsyncThunk(
   "pokemon/fetchMultiplePokemonById",
   async (maxPokemonId) => {
@@ -8,7 +25,7 @@ export const fetchMultiplePokemonById = createAsyncThunk(
       (_, idx) => idx + 1
     );
 
-    const fetchAPI = async (pokemonId) => {
+    const getPokemonData = async (pokemonId) => {
       // const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${pokemonId}/`);
       const response = await fetch(
         `https://pokeapi.co/api/v2/pokemon-species/${pokemonId}/`
@@ -33,6 +50,6 @@ export const fetchMultiplePokemonById = createAsyncThunk(
       return pokemonData;
     };
 
-    return await Promise.all(numberArray.map((el) => fetchAPI(el)));
+    return await Promise.all(numberArray.map((el) => getPokemonData(el)));
   }
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,15 +1,17 @@
 import Card from "../components/Card";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchMultiplePokemonById } from "../RTK/thunk";
+import { fetchMultiplePokemonById, fetchPokemonId } from "../RTK/thunk";
 
 const Home = () => {
   const dispatch = useDispatch();
   const pokemonData = useSelector((state) => state.pokemon.data);
-  console.log(pokemonData);
+  const pokemonIdList = useSelector((state) => state.pokemonId.data);
+  console.log("pokemonIdList : ", pokemonIdList);
 
   useEffect(() => {
     dispatch(fetchMultiplePokemonById(151));
+    dispatch(fetchPokemonId());
   }, [dispatch]);
 
   return (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,12 +7,17 @@ const Home = () => {
   const dispatch = useDispatch();
   const pokemonData = useSelector((state) => state.pokemon.data);
   const pokemonIdList = useSelector((state) => state.pokemonId.data);
-  console.log("pokemonIdList : ", pokemonIdList);
+  console.log("pokemonData : ", pokemonData);
 
   useEffect(() => {
-    dispatch(fetchMultiplePokemonById(151));
     dispatch(fetchPokemonId());
   }, [dispatch]);
+
+  useEffect(() => {
+    if (pokemonIdList.length > 0) {
+      dispatch(fetchMultiplePokemonById(pokemonIdList));
+    }
+  }, [dispatch, pokemonIdList]);
 
   return (
     <section className="px-16 py-8 flex flex-wrap justify-center gap-12 grow bg-[#747474]">


### PR DESCRIPTION
## 🌱 연관된 이슈

> #21

## 📝 작업 내용

> 기존에 불러오던 1세대 대신 4세대 포켓몬 리스트를 불러오도록 RTK 파일 및 api 경로 수정
